### PR TITLE
xconf below data/ dir are not applied properly

### DIFF
--- a/pre-install.xql
+++ b/pre-install.xql
@@ -34,8 +34,9 @@ local:mkcol("/db/system/config", $target),
 xmldb:store-files-from-pattern("/db/system/config" || $target,  $dir, "replication.xconf"),
 
 (: store the collection configuration :)
-for $xconf in file:directory-list(concat($dir, "/data"), "*.xconf")/file:file/@name
-let $data-dir := substring-before($xconf, ".xconf")
+let $dir := concat($dir, "/data")
+for $xconf in file:directory-list($dir, "*.xconf")/file:file/@name
+let $data-dir := concat("data/", substring-before($xconf, ".xconf"))
 return (
     local:mkcol-recursive(concat("/db/system/config/", $target), $data-dir),
     xmldb:store-files-from-pattern(


### PR DESCRIPTION
causes a performance bottleneck for pages like

http://history.state.gov/departmenthistory/people/by-year/2013

(backend servers already updated)